### PR TITLE
bump go version to 1.24

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.60.3
+          version: v2.3.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/turchenkoalex/ecwid-images-downloader
 
-go 1.23
+go 1.24.6

--- a/status/reporter.go
+++ b/status/reporter.go
@@ -63,8 +63,8 @@ func (status *Reporter) MarkAllProductsScheduled() {
 }
 
 func (status *Reporter) allImagesScheduled() bool {
-	return 1 == atomic.LoadInt32(&status.allCategoriesScheduled) &&
-		1 == atomic.LoadInt32(&status.allProductsScheduled)
+	return atomic.LoadInt32(&status.allCategoriesScheduled) == 1 &&
+		atomic.LoadInt32(&status.allProductsScheduled) == 1
 }
 
 func (status *Reporter) MarkImageDownloaded(success bool) {


### PR DESCRIPTION
This pull request updates the project's Go tooling and dependencies to use the latest versions. The main changes are upgrading the Go language version and updating the `golangci-lint` GitHub Action to a newer major version.

Dependency and tooling upgrades:

* Updated the Go version in `go.mod` from `1.23` to `1.24.6`, ensuring compatibility with the latest language features and security updates.
* Upgraded the `golangci-lint-action` in `.github/workflows/golangci-lint.yml` from version `v6` to `v8` and set the linter version to `v2.3.1` (was `v1.60.3`), providing improved linting capabilities and bug fixes.