### PR TITLE
Add token argument to API access and update related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Usage of ./ecwid-images-downloader-darwin-arm64:
     	Store ID
   -use-combinations
     	Download combination images
+  -token string
+    	APIv3 token (if not provided retrieve public token from Instant Site API)
   -verbose
     	Detailed logs
 ```

--- a/api/token.go
+++ b/api/token.go
@@ -43,7 +43,16 @@ func RetrievePublicToken(httpClient *http.Client, storeId int64) string {
 		return ""
 	}
 
-	return r.StoreProfile.Value.AppsSettings.PublicTokens["ecwid-storefront"]
+	if r.StoreProfile.Value.AppsSettings.PublicTokens == nil {
+		return ""
+	}
+
+	token, ok := r.StoreProfile.Value.AppsSettings.PublicTokens["ecwid-storefront"]
+	if !ok {
+		return ""
+	}
+
+	return token
 }
 
 type tokenResponse struct {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,6 +17,7 @@ type Options struct {
 	DownloadDir     string
 	SkipDownloaded  bool
 	IncludeNames    bool
+	Token           string
 }
 
 var options Options
@@ -32,6 +33,7 @@ func init() {
 	flag.BoolVar(&options.SkipCategories, "skip-categories", false, "Skip categories images")
 	flag.BoolVar(&options.IncludeNames, "include-names", false, "Use product names in image file names")
 	flag.StringVar(&options.DownloadDir, "download-dir", "", "Dir for download images (default: downloads/storeId)")
+	flag.StringVar(&options.Token, "token", "", "Token to access API v3 (if not provided, will try to retrieve public token)")
 }
 
 func ReadOptions() (Options, error) {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -12,7 +12,7 @@ import (
 	"github.com/turchenkoalex/ecwid-images-downloader/status"
 )
 
-func DownloadProducts(ctx context.Context, httpClient *http.Client, options Options, publicToken string, imagesChan chan api.Image, status *status.Reporter) {
+func DownloadProducts(ctx context.Context, httpClient *http.Client, options Options, apiToken string, imagesChan chan api.Image, status *status.Reporter) {
 	limit := options.FetchLimit
 	offset := 0
 	total := status.GetTotalProductsCount()
@@ -25,7 +25,7 @@ func DownloadProducts(ctx context.Context, httpClient *http.Client, options Opti
 			// continue processing
 		}
 
-		products, err := api.LoadProducts(httpClient, options.StoreID, publicToken, offset, limit)
+		products, err := api.LoadProducts(httpClient, options.StoreID, apiToken, offset, limit)
 		if err != nil {
 			fmt.Println("Download interrupted", err)
 			return
@@ -56,7 +56,7 @@ func DownloadProducts(ctx context.Context, httpClient *http.Client, options Opti
 				go func() {
 					defer wg.Done()
 					// Загрузим параллельно комбинации товара и поставим их картинки в очередь
-					downloadCombinations(ctx, httpClient, productId, productName, options, publicToken, imagesChan, status)
+					downloadCombinations(ctx, httpClient, productId, productName, options, apiToken, imagesChan, status)
 				}()
 			}
 
@@ -70,8 +70,8 @@ func DownloadProducts(ctx context.Context, httpClient *http.Client, options Opti
 	status.MarkAllProductsScheduled()
 }
 
-func downloadCombinations(ctx context.Context, httpClient *http.Client, productId int, productName string, options Options, publicToken string, imagesChan chan api.Image, status *status.Reporter) {
-	combinations, err := api.LoadProductCombinations(httpClient, options.StoreID, publicToken, productId)
+func downloadCombinations(ctx context.Context, httpClient *http.Client, productId int, productName string, options Options, apiToken string, imagesChan chan api.Image, status *status.Reporter) {
+	combinations, err := api.LoadProductCombinations(httpClient, options.StoreID, apiToken, productId)
 	if err == nil {
 		for _, combination := range combinations {
 			select {
@@ -90,7 +90,7 @@ func downloadCombinations(ctx context.Context, httpClient *http.Client, productI
 	}
 }
 
-func DownloadCategories(ctx context.Context, httpClient *http.Client, options Options, publicToken string, imagesChan chan api.Image, status *status.Reporter) {
+func DownloadCategories(ctx context.Context, httpClient *http.Client, options Options, apiToken string, imagesChan chan api.Image, status *status.Reporter) {
 	limit := options.FetchLimit
 	offset := 0
 	total := status.GetTotalCategoriesCount()
@@ -103,7 +103,7 @@ func DownloadCategories(ctx context.Context, httpClient *http.Client, options Op
 			// continue processing
 		}
 
-		categories, err := api.LoadCategories(httpClient, options.StoreID, publicToken, offset, limit)
+		categories, err := api.LoadCategories(httpClient, options.StoreID, apiToken, offset, limit)
 		if err != nil {
 			fmt.Println("Download interrupted", err)
 			return


### PR DESCRIPTION
This pull request adds support for specifying an APIv3 token via a new `-token` command-line argument, allowing users to provide their own token for authentication. If the token is not provided, the application will attempt to retrieve a public token as before, but with improved error handling and messaging. The changes also update the codebase to consistently use the provided or retrieved token throughout all API calls.

**Authentication and Token Handling:**

* Added a new `-token` command-line argument to allow users to specify an APIv3 token; updated the `Options` struct and CLI flag parsing to support this. [[1]](diffhunk://#diff-8e494a434a8037b6c0b888e25b2baae7618fe65e792d4a155dadd096e9350667R20) [[2]](diffhunk://#diff-8e494a434a8037b6c0b888e25b2baae7618fe65e792d4a155dadd096e9350667R36) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R32)
* Modified the main application logic in `main.go` to use the provided token if available, or fall back to retrieving a public token, with improved error messages if neither is available. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L48-R62) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L59-R71)
* Updated all API-calling functions and their invocations to use the unified `apiToken` variable instead of `publicToken`, ensuring consistent authentication. [[1]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dL15-R15) [[2]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dL28-R28) [[3]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dL59-R59) [[4]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dL73-R74) [[5]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dL93-R93) [[6]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dL106-R106) [[7]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L68-R88) [[8]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L118-R130) [[9]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L129-R141)

**Reliability Improvements:**

* Improved the `RetrievePublicToken` function to safely handle cases where the `PublicTokens` map is missing or does not contain the expected key, preventing potential panics.